### PR TITLE
Fix evaluate confusion matrix message

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -35,7 +35,7 @@ def evaluate():
     plt.close()
 
     print("Rapport sauvegardé dans reports/classification-report.txt")
-    print("Matrice de confusion sauvegardée dans reports/confusion-matrix.jpg")
+    print("Matrice de confusion sauvegardée dans reports/confusion-matrix.png")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- correct the extension mentioned when saving confusion matrix in `evaluate.py`

## Testing
- `python -m py_compile evaluate.py`
- `make evaluations` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68665ba7c1e4832a9afab8342483e45f