### PR TITLE
Add pipeline tests

### DIFF
--- a/clean_data.py
+++ b/clean_data.py
@@ -1,10 +1,12 @@
 import pandas as pd
 
 
-def clean_data():
-    df = pd.read_csv("data/raw_dataset.csv")
+def clean_data(src: str = "data/raw_dataset.csv", dest: str = "data/clean_dataset.csv"):
+    """Clean the dataset by removing identifier columns."""
+
+    df = pd.read_csv(src)
     df = df.drop(["RowNumber", "CustomerId"], axis=1)
-    df.to_csv("data/clean_dataset.csv", index=False)
+    df.to_csv(dest, index=False)
 
 
 if __name__ == "__main__":

--- a/evaluate.py
+++ b/evaluate.py
@@ -7,16 +7,24 @@ from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
 import matplotlib.pyplot as plt
 
 
-def evaluate():
-    df = pd.read_csv("data/clean_dataset.csv")
+def evaluate(
+    data_csv: str = "data/clean_dataset.csv",
+    features_file: str = "data/preprocessed_features.npz",
+    model_path: str = "model.pkl",
+    report_path: str = "reports/classification-report.txt",
+    matrix_path: str = "reports/confusion-matrix.png",
+):
+    """Evaluate the trained model and save evaluation artefacts."""
+
+    df = pd.read_csv(data_csv)
     y = df["Exited"]
-    X = sparse.load_npz("data/preprocessed_features.npz")
+    X = sparse.load_npz(features_file)
 
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, stratify=y, random_state=42
     )
 
-    with open("model.pkl", "rb") as f:
+    with open(model_path, "rb") as f:
         svc = load(f)
 
     y_test_pred = svc.predict(X_test)
@@ -27,11 +35,11 @@ def evaluate():
     disp = ConfusionMatrixDisplay(confusion_matrix=cm, display_labels=svc.classes_)
 
     # Afficher et sauvegarder
-    with open("reports/classification-report.txt", "w") as f:
+    with open(report_path, "w") as f:
         f.write(clf_report)
 
     disp.plot()
-    plt.savefig("reports/confusion-matrix.png")
+    plt.savefig(matrix_path)
     plt.close()
 
     print("Rapport sauvegardé dans reports/classification-report.txt")

--- a/load_data.py
+++ b/load_data.py
@@ -3,9 +3,19 @@ import pandas as pd
 data_link = "https://raw.githubusercontent.com/jslhost/dataset_repo/refs/heads/main/Churn_Modelling.csv"
 
 
-def load_data():
-    df = pd.read_csv(data_link)
-    df.to_csv("data/raw_dataset.csv", index=False)
+def load_data(src: str = data_link, dest: str = "data/raw_dataset.csv"):
+    """Load the dataset from ``src`` and save it to ``dest``.
+
+    Parameters
+    ----------
+    src: str
+        Path or URL to the CSV file to load.
+    dest: str
+        Path of the CSV file to write.
+    """
+
+    df = pd.read_csv(src)
+    df.to_csv(dest, index=False)
 
 
 if __name__ == "__main__":

--- a/preprocess_data.py
+++ b/preprocess_data.py
@@ -32,14 +32,12 @@ def preprocess_data(src: str = "data/clean_dataset.csv", dest: str = "data/prepr
                 categorical_transformer,
                 make_column_selector(dtype_include=object),
             ),
-        ],
-        sparse_threshold=0.0,
+        ]
     )
 
     pipeline = Pipeline(steps=[("preprocessor", preprocessor)])
 
     X_preprocessed = pipeline.fit_transform(X)
-    X_preprocessed = sparse.csr_matrix(X_preprocessed)
 
     sparse.save_npz(dest, X_preprocessed)
 

--- a/preprocess_data.py
+++ b/preprocess_data.py
@@ -8,8 +8,10 @@ from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.compose import ColumnTransformer, make_column_selector
 
 
-def preprocess_data():
-    df = pd.read_csv("data/clean_dataset.csv")
+def preprocess_data(src: str = "data/clean_dataset.csv", dest: str = "data/preprocessed_features.npz"):
+    """Preprocess features and save them as a sparse matrix."""
+
+    df = pd.read_csv(src)
     X = df.drop("Exited", axis=1)
 
     numeric_transformer = Pipeline(
@@ -30,14 +32,16 @@ def preprocess_data():
                 categorical_transformer,
                 make_column_selector(dtype_include=object),
             ),
-        ]
+        ],
+        sparse_threshold=0.0,
     )
 
     pipeline = Pipeline(steps=[("preprocessor", preprocessor)])
 
     X_preprocessed = pipeline.fit_transform(X)
+    X_preprocessed = sparse.csr_matrix(X_preprocessed)
 
-    sparse.save_npz("data/preprocessed_features.npz", X_preprocessed)
+    sparse.save_npz(dest, X_preprocessed)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 scikit-learn
 matplotlib
+pytest

--- a/tests/sample_data.csv
+++ b/tests/sample_data.csv
@@ -1,0 +1,9 @@
+RowNumber,CustomerId,Surname,CreditScore,Geography,Gender,Age,Tenure,Balance,NumOfProducts,HasCrCard,IsActiveMember,EstimatedSalary,Exited
+1,15634602,Hargrave,619,France,Female,42,2,0.0,1,1,1,101348.88,1
+2,15647311,Hill,608,Spain,Female,41,1,83807.86,1,0,1,112542.58,0
+3,15619304,Onoseke,502,France,Male,42,8,1099.68,3,1,1,1355.95,1
+4,15701354,Smith,651,Germany,Male,50,5,50000.00,2,1,0,123456.78,0
+5,15701355,Brown,600,France,Female,30,3,2000.00,1,1,1,40000.00,1
+6,15701356,Taylor,630,Germany,Female,40,6,3000.00,2,1,1,50000.00,0
+7,15701357,Wilson,680,Spain,Male,36,4,1200.00,2,0,1,60000.00,1
+8,15701358,Johnson,590,France,Male,29,2,0.00,1,1,0,70000.00,0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,80 @@
+import os
+from pathlib import Path
+
+import pandas as pd
+from scipy import sparse
+
+from load_data import load_data
+from clean_data import clean_data
+from preprocess_data import preprocess_data
+from training import training
+from evaluate import evaluate
+
+
+def test_load_and_clean(tmp_path):
+    # setup temporary data folder
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    raw_path = data_dir / "raw.csv"
+    clean_path = data_dir / "clean.csv"
+
+    load_data(src="tests/sample_data.csv", dest=raw_path)
+    assert raw_path.exists(), "Raw dataset should be created"
+
+    df_raw = pd.read_csv(raw_path)
+    assert not df_raw.empty, "Raw dataset should not be empty"
+
+    clean_data(src=raw_path, dest=clean_path)
+    df_clean = pd.read_csv(clean_path)
+
+    assert "RowNumber" not in df_clean.columns
+    assert "CustomerId" not in df_clean.columns
+    assert len(df_clean) == len(df_raw)
+
+
+def test_preprocess(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    clean_path = data_dir / "clean.csv"
+    features_path = data_dir / "feat.npz"
+
+    # prepare clean data
+    df = pd.read_csv("tests/sample_data.csv")
+    df.drop(["RowNumber", "CustomerId"], axis=1).to_csv(clean_path, index=False)
+
+    preprocess_data(src=clean_path, dest=features_path)
+    assert features_path.exists()
+
+    X = sparse.load_npz(features_path)
+    assert X.shape[0] == len(df)
+
+
+def test_training_and_evaluate(tmp_path):
+    data_dir = tmp_path / "data"
+    report_dir = tmp_path / "reports"
+    data_dir.mkdir()
+    report_dir.mkdir()
+    clean_path = data_dir / "clean.csv"
+    features_path = data_dir / "feat.npz"
+    model_path = tmp_path / "model.pkl"
+    report_path = report_dir / "report.txt"
+    matrix_path = report_dir / "matrix.png"
+
+    df = pd.read_csv("tests/sample_data.csv")
+    df.drop(["RowNumber", "CustomerId"], axis=1).to_csv(clean_path, index=False)
+    preprocess_data(src=clean_path, dest=features_path)
+
+    training(data_csv=clean_path, features_file=features_path, model_path=model_path)
+    assert model_path.exists()
+
+    evaluate(
+        data_csv=clean_path,
+        features_file=features_path,
+        model_path=model_path,
+        report_path=report_path,
+        matrix_path=matrix_path,
+    )
+
+    assert report_path.exists()
+    assert matrix_path.exists()
+

--- a/training.py
+++ b/training.py
@@ -6,10 +6,12 @@ from sklearn.model_selection import train_test_split
 from sklearn.svm import SVC
 
 
-def training():
-    df = pd.read_csv("data/clean_dataset.csv")
+def training(data_csv: str = "data/clean_dataset.csv", features_file: str = "data/preprocessed_features.npz", model_path: str = "model.pkl"):
+    """Train a SVC model and save it to ``model_path``."""
+
+    df = pd.read_csv(data_csv)
     y = df["Exited"]
-    X = sparse.load_npz("data/preprocessed_features.npz")
+    X = sparse.load_npz(features_file)
 
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=0.2, stratify=y, random_state=42
@@ -19,7 +21,7 @@ def training():
 
     svc.fit(X_train, y_train)
 
-    with open("model.pkl", "wb") as f:
+    with open(model_path, "wb") as f:
         dump(svc, f, protocol=5)
 
 


### PR DESCRIPTION
## Summary
- add parameters to pipeline functions so paths can be overridden
- implement preprocessing with sparse output
- provide pytest-based test suite with sample dataset
- add pytest to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686660c35c0c832ab82ddaf3e6ffca9c